### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/publish-auto-archiver.yml
+++ b/.github/workflows/publish-auto-archiver.yml
@@ -17,7 +17,7 @@ jobs:
       run: echo ::set-output name=tag::${GITHUB_REF:24}
 
     - name: publish docker image
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: feedbax/backend/backend-auto-archiver
         username: ${{ github.actor }}

--- a/.github/workflows/publish-server.yml
+++ b/.github/workflows/publish-server.yml
@@ -24,7 +24,7 @@ jobs:
 
 
     - name: publish docker image
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: feedbax/backend/backend-server
         username: ${{ github.actor }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore